### PR TITLE
explicit dataset licenses

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,13 +1,17 @@
 alchemtest: the simple alchemistry test set
 ===========================================
 
-**Warning**: This library is young. It is **not** API stable. It is a
-nucleation point. By all means use and help improve it, but note that it will
-change with time.
-
 **alchemtest**  is a collection of test datasets for alchemical free energy calculations.
 The datasets come from a variety of software packages, primarily molecular
 dynamics engines, and are used as the test set for `alchemlyb`_.
 The package is standalone, however, and can be used for any purpose.
 
+Datasets are released under an `open license`_ that conforms to the
+`Open Definition 2.1`_) that allows free use, re-use, redistribution,
+modification, separation, for any purpose and without a charge.
+
+
 .. _`alchemlyb`: https://github.com/alchemistry/alchemlyb
+.. _`open license`:
+   http://opendefinition.org/licenses/#recommended-conformant-licenses
+.. _`Open Definition 2.1`: http://opendefinition.org/od/2.1/en/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,13 +6,18 @@
 alchemtest: the simple alchemistry test set
 ===========================================
 
-.. warning:: This library is in an **alpha** state. The library and the documentation is incomplete. Use in production at your own risk.
+**alchemtest** is a collection of test datasets for alchemical free energy calculations.  The datasets come from a variety of software packages, primarily molecular dynamics engines, and are used as the test set for `alchemlyb`_.  The package is standalone, however, and can be used for any purpose.
 
-**alchemtest**  is a collection of test datasets for alchemical free energy calculations.
-The datasets come from a variety of software packages, primarily molecular dynamics engines, and are used as the test set for `alchemlyb`_.
-The package is standalone, however, and can be used for any purpose.
+Datasets are released under an `open license`_ that conforms to the `Open Definition 2.1`_) that allows free use, re-use, redistribution, modification, separation, for any purpose and without a charge.
+
 
 .. _`alchemlyb`: https://github.com/alchemistry/alchemlyb
+.. _`open license`:
+   http://opendefinition.org/licenses/#recommended-conformant-licenses
+.. _`Open Definition 2.1`: http://opendefinition.org/od/2.1/en/
+
+.. note:: This library is in an **alpha** state. The library and the documentation is incomplete. Use in production at your own risk.
+
 
 .. toctree::
     :maxdepth: 1

--- a/src/alchemtest/gmx/benzene/descr.rst
+++ b/src/alchemtest/gmx/benzene/descr.rst
@@ -12,18 +12,18 @@ Data Set Characteristics:
     :Pressure: 1 bar
     :Alchemical Pathway: vdw + coul --> vdw --> vacuum
     :Experimental Hydration Free Energy: -0.90 +- 0.2 kcal/mol
-
     :Missing Values: None
     :Creator: \I. Kenney
     :Donor: Ian Kenney (ian.kenney@asu.edu)
     :Date: March 2017
-
+    :License: `CC0 <https://creativecommons.org/publicdomain/zero/1.0/>`_ Public Domain Dedication 
+	      
 Benzene in water, alchemically turned into benzene in vacuum separated from water
 
 This dataset was generated using `MDPOW <https://github.com/Becksteinlab/MDPOW>`_, with
 the `Gromacs <http://www.gromacs.org/>`_ molecular dynamics engine. 
 
-Experimental value sourced from [Mobley2013].
+Experimental value sourced from [Mobley2013]_.
 
 .. [Mobley2013] Mobley, David L. (2013). Experimental and Calculated Small 
     Molecule Hydration Free Energies. UC Irvine: Department of Pharmaceutical 


### PR DESCRIPTION
Make explicit that datasets are distributed under an [open license](http://opendefinition.org/licenses/#recommended-conformant-licenses) (a recommended license conforming to the [Open Definition 2.1](http://opendefinition.org/od/2.1/en/)

The GMX dataset was explicitly put under the CC0 (public domain) by adding a *License* field to the description. 

The wiki page on [Contributing: Licenses](https://github.com/alchemistry/alchemtest/wiki/contributing#licensing) was also updated.