### PR TITLE
updated docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ dynamics engines, and are used as the test set for `alchemlyb`_.
 The package is standalone, however, and can be used for any purpose.
 
 Datasets are released under an `open license`_ that conforms to the
-`Open Definition 2.1`_) that allows free use, re-use, redistribution,
+`Open Definition 2.1`_ that allows free use, re-use, redistribution,
 modification, separation, for any purpose and without a charge.
 
 

--- a/docs/amber.rst
+++ b/docs/amber.rst
@@ -6,9 +6,9 @@ Amber datasets
 
 .. automodule:: alchemtest.amber
 
-The :mod:`alchemlyb.amber` module features datasets generated using the `Amber
-<http://www.ambermd.org/>`_ molecular dynamics engine.  They can be accessed
-using the following accessor functions:
+The :mod:`alchemlyb.amber` module features datasets generated using
+the `Amber <http://www.ambermd.org/>`_ molecular dynamics engine.
+They can be accessed using the following accessor functions:
 
 .. currentmodule:: alchemtest.amber
 

--- a/docs/amber.rst
+++ b/docs/amber.rst
@@ -1,22 +1,31 @@
-.. _amber:
+.. _amber-datasets:
 
-================
+==============
 Amber datasets
-================
+==============
+
 .. automodule:: alchemtest.amber
 
-The :mod:`alchemlyb.amber` module features datasets generated using the `Amber <http://www.ambermd.org/>`_ molecular dynamics engine. 
-They can be accessed using the following accessor functions:
+The :mod:`alchemlyb.amber` module features datasets generated using the `Amber
+<http://www.ambermd.org/>`_ molecular dynamics engine.  They can be accessed
+using the following accessor functions:
 
 .. currentmodule:: alchemtest.amber
 
 .. autosummary::
 
    load_simplesolvated
-
+   load_invalidfiles
 
 .. _amber_simplesolvated:
 
 .. include:: ../src/alchemtest/amber/simplesolvated/descr.rst
 
 .. autofunction:: alchemtest.amber.load_simplesolvated
+
+
+.. _amber_invalidfiles:
+
+.. include:: ../src/alchemtest/amber/invalidfiles/descr.rst
+	     
+.. autofunction:: alchemtest.amber.load_invalidfiles

--- a/docs/gmx.rst
+++ b/docs/gmx.rst
@@ -1,4 +1,4 @@
-.. _gmx:
+.. _gmx-datasets:
 
 ================
 Gromacs datasets

--- a/docs/gmx.rst
+++ b/docs/gmx.rst
@@ -5,8 +5,9 @@ Gromacs datasets
 ================
 .. automodule:: alchemtest.gmx
 
-The :mod:`alchemlyb.gmx` module features datasets generated using the `Gromacs <http://www.gromacs.org/>`_ molecular dynamics engine. 
-They can be accessed using the following accessor functions:
+The :mod:`alchemlyb.gmx` module features datasets generated using the
+`Gromacs <http://www.gromacs.org/>`_ molecular dynamics engine.  They
+can be accessed using the following accessor functions:
 
 .. currentmodule:: alchemtest.gmx
 

--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -1,0 +1,13 @@
+.. _helpers:
+
+==============================
+ Helper functions and classes
+==============================
+
+A small number of functions and classes are included to help organize
+the data.
+
+.. currentmodule:: alchemtest
+		   
+.. autoclass:: Bunch
+   :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,9 +6,15 @@
 alchemtest: the simple alchemistry test set
 ===========================================
 
-**alchemtest** is a collection of test datasets for alchemical free energy calculations.  The datasets come from a variety of software packages, primarily molecular dynamics engines, and are used as the test set for `alchemlyb`_.  The package is standalone, however, and can be used for any purpose.
+**alchemtest** is a collection of test datasets for alchemical free energy
+ calculations.  The datasets come from a variety of software packages,
+ primarily molecular dynamics engines, and are used as the test set for
+ `alchemlyb`_.  The package is standalone, however, and can be used for any
+ purpose.
 
-Datasets are released under an `open license`_ that conforms to the `Open Definition 2.1`_) that allows free use, re-use, redistribution, modification, separation, for any purpose and without a charge.
+Datasets are released under an `open license`_ that conforms to the `Open
+Definition 2.1`_ that allows free use, re-use, redistribution, modification,
+separation, for any purpose and without a charge.
 
 
 .. _`alchemlyb`: https://github.com/alchemistry/alchemlyb
@@ -16,7 +22,8 @@ Datasets are released under an `open license`_ that conforms to the `Open Defini
    http://opendefinition.org/licenses/#recommended-conformant-licenses
 .. _`Open Definition 2.1`: http://opendefinition.org/od/2.1/en/
 
-.. note:: This library is in an **alpha** state. The library and the documentation is incomplete. Use in production at your own risk.
+.. note:: This library is in an **alpha** state. The library and the
+          documentation is incomplete. Use in production at your own risk.
 
 
 .. toctree::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,7 @@ Datasets are released under an `open license`_ that conforms to the `Open Defini
 
     install
     usage
+    helpers
 
 .. toctree::
     :maxdepth: 1

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,11 +1,13 @@
 Installing alchemtest
 =====================
 
-**alchemtest** is pure-Python, so it can be installed easily via ``pip``::
+**alchemtest** is pure-Python, so it can be installed easily via
+ ``pip``::
 
     pip install alchemtest
 
-If you wish to install this in your user ``site-packages``, use the ``--user`` flag::
+If you wish to install this in your user ``site-packages``, use the
+``--user`` flag::
 
     pip install --user alchemtest
 
@@ -22,7 +24,8 @@ then do::
     cd alchemtest
     pip install .
 
-If you wish to install this in your user ``site-packages``, use the ``--user`` flag::
+If you wish to install this in your user ``site-packages``, use the
+``--user`` flag::
 
     pip install --user .
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -10,20 +10,22 @@ The current set of submodules are:
 .. autosummary::
 
    gmx
-
+   amber
 
 As an example, we can access the :ref:`gmx_benzene` dataset with::
 
     >>> from alchemtest.gmx import load_benzene
     >>> bz = load_benzene()
 
-and use the resulting ``Bunch`` object to introspect what this dataset includes.
+and use the resulting :class:`Bunch` object to introspect what this dataset includes.
 In particular, it features a ``DESCR`` attribute with a human-readable description of the dataset::
 
     >>> print(bz.DESCR)
     Gromacs: Benzene in water
     =========================
-    
+
+    Benzene in water, alchemically turned into benzene in vacuum separated from water
+      
     Notes
     -----
     Data Set Characteristics:
@@ -35,8 +37,9 @@ In particular, it features a ``DESCR`` attribute with a human-readable descripti
         :Creator: \I. Kenney
         :Donor: Ian Kenney (ian.kenney@asu.edu)
         :Date: March 2017
-    
-    Benzene in water, alchemically turned into benzene in vacuum separated from water
+        :License: `CC0
+                  <https://creativecommons.org/publicdomain/zero/1.0/>`_
+                  Public Domain Dedication
     
     This dataset was generated using `MDPOW <https://github.com/Becksteinlab/MDPOW>`_, with
     the `Gromacs <http://www.gromacs.org/>`_ molecular dynamics engine. 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -2,8 +2,10 @@
 
 Basic usage
 ===========
-All datasets in :mod:`alchemtest` are accessible via ``load_*`` functions, organized in submodules by the software package that generated them.
-The current set of submodules are:
+
+All datasets in :mod:`alchemtest` are accessible via ``load_*``
+functions, organized in submodules by the software package that
+generated them.  The current set of submodules are:
 
 .. currentmodule:: alchemtest
 
@@ -17,8 +19,9 @@ As an example, we can access the :ref:`gmx_benzene` dataset with::
     >>> from alchemtest.gmx import load_benzene
     >>> bz = load_benzene()
 
-and use the resulting :class:`Bunch` object to introspect what this dataset includes.
-In particular, it features a ``DESCR`` attribute with a human-readable description of the dataset::
+and use the resulting :class:`Bunch` object to introspect what this
+dataset includes.  In particular, it features a ``DESCR`` attribute
+with a human-readable description of the dataset::
 
     >>> print(bz.DESCR)
     Gromacs: Benzene in water
@@ -49,8 +52,9 @@ as well as the dataset itself::
     >>>  bz.data.keys()
     ['VDW', 'Coulomb']
 
-which consists in this case of two alchemical legs, each having several files.
-For this dataset each file happens to correspond to a simulation sampling a particular :math:`\lambda`::
+which consists in this case of two alchemical legs, each having
+several files.  For this dataset each file happens to correspond to a
+simulation sampling a particular :math:`\lambda`::
 
     >>> bz.data['Coulomb']
     ['/usr/local/python3.6/site-packages/alchemtest/gmx/benzene/Coulomb/0000/dhdl.xvg.bz2',
@@ -59,5 +63,6 @@ For this dataset each file happens to correspond to a simulation sampling a part
      '/usr/local/python3.6/site-packages/alchemtest/gmx/benzene/Coulomb/0750/dhdl.xvg.bz2',
      '/usr/local/python3.6/site-packages/alchemtest/gmx/benzene/Coulomb/1000/dhdl.xvg.bz2']
 
-These paths can be read by any appropriate parser for further analysis.
-For this particular dataset, see :mod:`alchemlyb.parsing.gmx` for a good set of parsers.
+These paths can be read by any appropriate parser for further
+analysis.  For this particular dataset, see
+:mod:`alchemlyb.parsing.gmx` for a good set of parsers.

--- a/src/alchemtest/amber/access.py
+++ b/src/alchemtest/amber/access.py
@@ -2,8 +2,7 @@
 
 """
 
-from os.path import dirname
-from os.path import join
+from os.path import dirname, join
 from glob import glob
 
 from .. import Bunch
@@ -11,11 +10,11 @@ from .. import Bunch
 def load_simplesolvated():
     """Load the Amber solvated dataset.
 
-
     Returns
     -------
     data : Bunch
         Dictionary-like object, the interesting attributes are:
+
         - 'data' : the data files by alchemical leg
         - 'DESCR': the full description of the dataset
 
@@ -38,6 +37,7 @@ def load_invalidfiles():
     -------
     data : Bunch
         Dictionary-like object, the interesting attributes are:
+
         - 'data' : the example of invalid data files
         - 'DESCR': the full description of the dataset
 

--- a/src/alchemtest/amber/invalidfiles/descr.rst
+++ b/src/alchemtest/amber/invalidfiles/descr.rst
@@ -1,11 +1,14 @@
-Amber TI invalid output file examples for file validation testing:   
-=========================
+Amber TI invalid output files
+=============================
+
+Examples for file validation testing.
 
 Notes
 -----
-invalid-case-1.out.bz2: file contains no useful data
-invalid-case-2.out.bz2: file contains no control data
-invalid-case-3.out.bz2: file with Non-constant temperature
-invalid-case-4.out.bz2: file with no free energy section
-invalid-case-5.out.bz2: file with no ATOMIC section
-invalid-case-6.out.bz2: file with no RESULTS section
+
+- invalid-case-1.out.bz2: file contains no useful data
+- invalid-case-2.out.bz2: file contains no control data
+- invalid-case-3.out.bz2: file with Non-constant temperature
+- invalid-case-4.out.bz2: file with no free energy section
+- invalid-case-5.out.bz2: file with no ATOMIC section
+- invalid-case-6.out.bz2: file with no RESULTS section

--- a/src/alchemtest/amber/simplesolvated/descr.rst
+++ b/src/alchemtest/amber/simplesolvated/descr.rst
@@ -1,5 +1,9 @@
-Amber: Small molecule thermodynamic integration free energy difference in water. This example uses ligands 17124-1 to 18637-1 from J. Am. Chem. Soc. 2015, 137, 2695−2703. 
-=========================
+Amber: Small molecule thermodynamic integration free energy difference in water
+===============================================================================
+
+Small molecule perturbation in water, alchemically turned ligand 1 into ligand
+2 in water. This example uses ligands 17124-1 to 18637-1 from [Wang2015]_.
+
 
 Notes
 -----
@@ -10,13 +14,25 @@ Data Set Characteristics:
     :System Size: 5979 atoms
     :Temperature: 300 K
     :Pressure: 1 bar
-    :Alchemical Pathway: (charge + vdw) in ligand 1 --> (charge + vdw) in ligand 2, charge and vdw are running in parellel, soft core is used in vdw
+    :Alchemical Pathway: (charge + vdw) in ligand 1 --> (charge + vdw) in
+                         ligand 2, charge and vdw are running in parellel, soft
+                         core is used in vdw
     :Experimental Free Energy difference: N/A 
     :Missing Values: None
     :Date: Oct 2017
     :Donor: Silicon Therapeutics 
-    :License: `CC0 <https://creativecommons.org/publicdomain/zero/1.0/>`_ Public Domain Dedication
+    :License: `CC0 <https://creativecommons.org/publicdomain/zero/1.0/>`_
+              Public Domain Dedication
 
-Small molecule perturbation in water, alchemically turned ligand 1 into ligand 2 in water
+This dataset was generated using the `Amber <http://www.ambermd.org/>`_
+molecular dynamics engine.
+	      
 
-This dataset was generated using the `Amber <http://www.ambermd.org/>`_ molecular dynamics engine. 
+.. [Wang2015] L. Wang, Y. Wu, Y. Deng, B. Kim, L. Pierce, G. Krilov, D. Lupyan, S. Robinson, M. K. Dahlgren, J. Greenwood, D. L. Romero, C. Masse, J. L. Knight, T. Steinbrecher, T. Beuming, W. Damm, E. Harder, W. Sherman, M. Brewer, R. Wester, M. Murcko, L. Frye, R. Farid, T. Lin, D. L. Mobley, W. L. Jorgensen, B. J. Berne, R. A. Friesner,
+	      and R. Abel. Accurate and reliable prediction of
+              relative ligand binding potency in prospective drug
+              discovery by way of a modern free-energy calculation
+              protocol and force field. Journal of the American
+              Chemical Society,
+              137(7):2695–2703, 2015. PMID: 25625324. DOI:
+	      `10.1021/ja512751q <https://doi.org/10.1021/ja512751q>`_.

--- a/src/alchemtest/gmx/access.py
+++ b/src/alchemtest/gmx/access.py
@@ -2,8 +2,7 @@
 
 """
 
-from os.path import dirname
-from os.path import join
+from os.path import dirname, join
 from glob import glob
 
 from .. import Bunch
@@ -11,11 +10,11 @@ from .. import Bunch
 def load_benzene():
     """Load the Gromacs benzene dataset.
 
-
     Returns
     -------
     data : Bunch
         Dictionary-like object, the interesting attributes are:
+
         - 'data' : the data files by alchemical leg
         - 'DESCR': the full description of the dataset
 

--- a/src/alchemtest/gmx/benzene/descr.rst
+++ b/src/alchemtest/gmx/benzene/descr.rst
@@ -1,6 +1,8 @@
 Gromacs: Benzene in water
 =========================
 
+Benzene in water, alchemically turned into benzene in vacuum separated from water
+
 Notes
 -----
 Data Set Characteristics:
@@ -16,9 +18,9 @@ Data Set Characteristics:
     :Creator: \I. Kenney
     :Donor: Ian Kenney (ian.kenney@asu.edu)
     :Date: March 2017
-    :License: `CC0 <https://creativecommons.org/publicdomain/zero/1.0/>`_ Public Domain Dedication 
-	      
-Benzene in water, alchemically turned into benzene in vacuum separated from water
+    :License: `CC0
+	      <https://creativecommons.org/publicdomain/zero/1.0/>`_
+	      Public Domain Dedication       
 
 This dataset was generated using `MDPOW <https://github.com/Becksteinlab/MDPOW>`_, with
 the `Gromacs <http://www.gromacs.org/>`_ molecular dynamics engine. 


### PR DESCRIPTION
- dataset descriptions get a one line summary before the notes section:
  adjusted gmx and amber descr.rst files
- include Amber datasets
  - load_invalidfiles() had been forgotten
  - formatted Wang 2015 reference
  - fixed reST in description files
  - reference in main docs so that amber module is accessible
  - removed duplicated reST link targets
- reformatted gmx docs and updated example to include licensing
- added docs for Bunch (which now get linked from everywhere)