### PR TITLE
add units of energy and time to the descriptions of the datasets

### DIFF
--- a/src/alchemtest/amber/bace_CAT-13d~CAT-17a/descr.rst
+++ b/src/alchemtest/amber/bace_CAT-13d~CAT-17a/descr.rst
@@ -19,6 +19,8 @@ Data Set Characteristics:
                          core is used in vdw
     :Experimental Free Energy difference: -0.26 kcal/mol
     :Missing Values: None
+    :Energy unit: kcal/mol
+    :Time unit: ps	     
     :Date: Jan 2018
     :Donor: Silicon Therapeutics 
     :License: `CC0 <https://creativecommons.org/publicdomain/zero/1.0/>`_

--- a/src/alchemtest/amber/bace_improper/descr.rst
+++ b/src/alchemtest/amber/bace_improper/descr.rst
@@ -17,6 +17,8 @@ Data Set Characteristics:
     :Alchemical Pathway: vdw in ligand 1 --> vdw in ligand 2, softcore is used in vdw
     :Experimental Free Energy difference: N/A
     :Missing Values: None
+    :Energy unit: kcal/mol
+    :Time unit: ps		     
     :Date: Jan 2018
     :Donor: Silicon Therapeutics 
     :License: `CC0 <https://creativecommons.org/publicdomain/zero/1.0/>`_

--- a/src/alchemtest/amber/simplesolvated/descr.rst
+++ b/src/alchemtest/amber/simplesolvated/descr.rst
@@ -19,6 +19,8 @@ Data Set Characteristics:
                          core is used in vdw
     :Experimental Free Energy difference: N/A 
     :Missing Values: None
+    :Energy unit: kcal/mol
+    :Time unit: ps		     
     :Date: Oct 2017
     :Donor: Silicon Therapeutics 
     :License: `CC0 <https://creativecommons.org/publicdomain/zero/1.0/>`_

--- a/src/alchemtest/gmx/benzene/descr.rst
+++ b/src/alchemtest/gmx/benzene/descr.rst
@@ -15,6 +15,8 @@ Data Set Characteristics:
     :Alchemical Pathway: vdw + coul --> vdw --> vacuum
     :Experimental Hydration Free Energy: -0.90 +- 0.2 kcal/mol
     :Missing Values: None
+    :Energy unit: kJ/mol
+    :Time unit: ps		   
     :Creator: \I. Kenney
     :Donor: Ian Kenney (ian.kenney@asu.edu)
     :Date: March 2017

--- a/src/alchemtest/gmx/expanded_ensemble/case_1/descr.rst
+++ b/src/alchemtest/gmx/expanded_ensemble/case_1/descr.rst
@@ -14,6 +14,8 @@ Data Set Characteristics:
     :Temperature: 300 K
     :Alchemical Pathway: vdw + coul --> vdw --> vacuum
     :Missing Values: None
+    :Energy unit: kJ/mol
+    :Time unit: ps		   		     
     :Creator: \T. Jensen
     :Donor: Travis Jensen (travis.jensen@colorado.edu)
     :Date: November 2017

--- a/src/alchemtest/gmx/expanded_ensemble/case_2/descr.rst
+++ b/src/alchemtest/gmx/expanded_ensemble/case_2/descr.rst
@@ -14,6 +14,8 @@ Data Set Characteristics:
     :Temperature: 300 K
     :Alchemical Pathway: vdw + coul --> vdw --> vacuum
     :Missing Values: None
+    :Energy unit: kJ/mol
+    :Time unit: ps		     
     :Creator: \T. Jensen
     :Donor: Travis Jensen (travis.jensen@colorado.edu)
     :Date: November 2017

--- a/src/alchemtest/gmx/expanded_ensemble/case_3/descr.rst
+++ b/src/alchemtest/gmx/expanded_ensemble/case_3/descr.rst
@@ -14,6 +14,8 @@ Data Set Characteristics:
     :Temperature: 300 K
     :Alchemical Pathway: vdw + coul --> vdw --> vacuum
     :Missing Values: None
+    :Energy unit: kJ/mol
+    :Time unit: ps		     
     :Creator: \T. Jensen
     :Donor: Travis Jensen (travis.jensen@colorado.edu)
     :Date: November 2017

--- a/src/alchemtest/namd/tyr2ala/descr.rst
+++ b/src/alchemtest/namd/tyr2ala/descr.rst
@@ -19,6 +19,8 @@ Data Set Characteristics:
                          atoms are scaled with their environment.
     :Experimental Free Energy difference: N/A 
     :Missing Values: None
+    :Energy unit: kcal/mol
+    :Time unit: step		     
     :Date: Oct 2017
     :Donor: JC Gumbart
     :License: `CC0 <https://creativecommons.org/publicdomain/zero/1.0/>`_


### PR DESCRIPTION
We need to make clear what units the raw data files are in. These are important details so that we can make sure that alchemlyb does correct unit conversion.

Added units for the datasets
- Gromacs
- Amber
- NAMD

This came up in conjunction with issues alchemistry/alchemlyb#56, alchemistry/alchemlyb#57, and alchemistry/alchemlyb#75.