### PR TITLE
extended tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,21 @@
+[run]
+branch = True
+omit =
+    # omit all tests
+    src/alchemtest/tests/*
+    # omit the versioneer-installed _version.py
+    src/alchemtest/_version.py
+
+[report]
+exclude_lines =
+    # omit lines marked with: # pragma: no cover
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __unicode__
+    def __repr__
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -13,6 +13,10 @@ on:
     #   (from https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
     - cron: "0 0 * * *"
 
+concurrency:
+  group: "${{ github.ref }}-${{ github.head_ref }}"
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}
@@ -21,9 +25,24 @@ jobs:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
+        exclude:
+        - os: macOS-latest
+          python-version: 3.6
+        - os: macOS-latest
+          python-version: 3.7
+        - os: macOS-latest
+          python-version: 3.8
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+
+    - name: Setup python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Display Python version
+      run: python -c "import sys; print(sys.version)"
 
     - name: Additional info about the build
       shell: bash
@@ -32,28 +51,14 @@ jobs:
         df -h
         ulimit -a
 
-
-    # More info on options: https://github.com/conda-incubator/setup-miniconda
-    - uses: conda-incubator/setup-miniconda@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-        environment-file: devtools/conda-envs/test_env.yaml
-
-        channels: conda-forge,defaults
-
-        activate-environment: test
-        auto-update-conda: false
-        auto-activate-base: false
-        show-channel-urls: true
+    - name: Install pytest, pytest plugins
+      run: |
+        python -m pip install wheel
+        python -m pip install pytest pytest-cov pytest-pep8
 
     - name: Install package
-
-      # conda setup requires this special shell
-      shell: bash -l {0}
       run: |
-        python -m pip install . --no-deps
-        conda list
-
+        python -m pip install .
 
     - name: Run tests
 
@@ -66,6 +71,8 @@ jobs:
     - name: CodeCov
       uses: codecov/codecov-action@v1
       with:
+        name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}      
         file: ./coverage.xml
         flags: unittests
-        name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
+        fail_ci_if_error: true
+

--- a/src/alchemtest/tests/__init__.py
+++ b/src/alchemtest/tests/__init__.py
@@ -1,0 +1,32 @@
+import os
+
+class BaseDatasetTest(object):
+    # @pytest.fixture(scope="class",
+    #                 params = [(load_tyr2ala, ('forward', 'backward'), (1, 1)),
+    #                           ])
+    # def dataset(self, reques):
+    #   return super().dataset(request)
+
+    def dataset(self, request):
+        '''The input dataset is specified as:
+        load_method: The method for loading the dataset.
+        keys: The keys to the corresponding dataset.
+        value_length: The expected number of file for each key.
+        '''
+        load_method, keys, value_length = request.param
+        return load_method, keys, value_length
+
+    def test_num_files(self, dataset):
+        '''Test if the number of files matches with the expected number of
+        files.'''
+        load_method, keys, value_length = dataset
+        for index, key in enumerate(keys):
+            assert len(load_method().data[key]) == value_length[index]
+
+    def test_file_exist(self, dataset):
+        '''Test if files do exist.'''
+        load_method, keys, value_length = dataset
+        for key in keys:
+            for file in load_method().data[key]:
+                if not os.path.isfile(file):
+                    raise AssertionError('Missing file in data set: {}'.format(file))

--- a/src/alchemtest/tests/test_amber.py
+++ b/src/alchemtest/tests/test_amber.py
@@ -1,0 +1,38 @@
+'''Tests for all the AMBER datasets'''
+import pytest
+
+from alchemtest.amber import (load_bace_improper, load_bace_example,
+                              load_simplesolvated, load_invalidfiles, )
+
+
+
+from . import BaseDatasetTest
+
+class TestAMBER(BaseDatasetTest):
+    @pytest.fixture(scope="class",
+                    params = [(load_bace_improper, ('vdw',), (12,)),
+                              (load_simplesolvated, ('charge', 'vdw'), (5, 12)),
+                              ])
+    def dataset(self, request):
+        return super(TestAMBER, self).dataset(request)
+
+
+# difficult -- has sub dicts under 'complex'/'solvated' -> 'decharge', 'recharge', 'vdw'
+# class TestBACEexample(BaseDatasetTest):
+#     @pytest.fixture(scope="class",
+#                     params = [(load_bace_example, ('complex',), (12,)),
+#                               ])
+#     def dataset(self, request):
+#         return super().dataset(request)
+
+
+# class TestInvalidFiles(BaseDatasetTest):
+#     # can't get the list of list in data
+#     @pytest.fixture(scope="class",
+#                     params = [(load_invalidfiles, (slice(None),), (6,)),
+#                               ])
+#     def dataset(self, request):
+#         return super().dataset(request)
+
+
+

--- a/src/alchemtest/tests/test_gmx.py
+++ b/src/alchemtest/tests/test_gmx.py
@@ -1,13 +1,30 @@
 '''Tests for all the gromacs dataset'''
 import pytest
 
-from alchemtest.gmx import load_benzene
+from alchemtest.gmx import (load_benzene, load_ABFE,
+                            load_expanded_ensemble_case_1,
+                            load_expanded_ensemble_case_2,
+                            load_expanded_ensemble_case_3,
+                            load_water_particle_without_energy,
+                            load_water_particle_with_potential_energy,
+                            load_water_particle_with_total_energy,
+                            )
 
 from . import BaseDatasetTest
 
-class TestBenzene(BaseDatasetTest):
+
+class TestGROMACS(BaseDatasetTest):
     @pytest.fixture(scope="class",
                     params = [(load_benzene, ('Coulomb', 'VDW'), (5, 16)),
+                              (load_ABFE, ('complex', 'ligand'), (30, 20)),
+                              (load_expanded_ensemble_case_1, ('AllStates', ), (1,)),
+                              (load_expanded_ensemble_case_2, ('AllStates', ), (2,)),
+                              (load_expanded_ensemble_case_3, ('AllStates', ), (32,)),
+                              (load_water_particle_without_energy, ('AllStates', ), (38,)),
+                              (load_water_particle_with_potential_energy, ('AllStates', ), (38,)),
+                              (load_water_particle_with_total_energy, ('AllStates', ), (38,)),
                               ])
     def dataset(self, request):
-        return super().dataset(request)
+        return super(TestGROMACS, self).dataset(request)
+
+

--- a/src/alchemtest/tests/test_gmx.py
+++ b/src/alchemtest/tests/test_gmx.py
@@ -1,33 +1,13 @@
 '''Tests for all the gromacs dataset'''
-import os
 import pytest
 
 from alchemtest.gmx import load_benzene
 
-class TestBenzene:
+from . import BaseDatasetTest
+
+class TestBenzene(BaseDatasetTest):
     @pytest.fixture(scope="class",
                     params = [(load_benzene, ('Coulomb', 'VDW'), (5, 16)),
                               ])
     def dataset(self, request):
-        '''The input dataset is specified as:
-        load_method: The method for loading the dataset.
-        keys: The keys to the corresponding dataset.
-        value_length: The expected number of file for each key.
-        '''
-        load_method, keys, value_length = request.param
-        return load_method, keys, value_length
-
-    def test_num_files(self, dataset):
-        '''Test if the number of files matches with the expected number of
-        files.'''
-        load_method, keys, value_length = dataset
-        for index, key in enumerate(keys):
-            assert len(load_method().data[key]) == value_length[index]
-
-    def test_file_exist(self, dataset):
-        '''Test if files do exist.'''
-        load_method, keys, value_length = dataset
-        for key in keys:
-            for file in load_method().data[key]:
-                if not os.path.isfile(file):
-                    raise AssertionError('Missing file in data set: {}'.format(file))
+        return super().dataset(request)

--- a/src/alchemtest/tests/test_gomc.py
+++ b/src/alchemtest/tests/test_gomc.py
@@ -1,0 +1,15 @@
+'''Tests for all the GOMC dataset'''
+import pytest
+
+from alchemtest.gomc import load_benzene
+
+from . import BaseDatasetTest
+
+class TestGOMC(BaseDatasetTest):
+    # note that the GOMC data does not use a dict for data but directly returns
+    # a list; we can work around this peculiarity by using a slice instead of a key
+    @pytest.fixture(scope="class",
+                    params = [(load_benzene, (slice(None),), (23,)),
+                              ])
+    def dataset(self, request):
+        return super(TestGOMC, self).dataset(request)

--- a/src/alchemtest/tests/test_namd.py
+++ b/src/alchemtest/tests/test_namd.py
@@ -1,0 +1,15 @@
+'''Tests for all the NAMD datasets'''
+import pytest
+
+from alchemtest.namd import load_tyr2ala, load_idws
+
+from . import BaseDatasetTest
+
+
+class TestNAMD(BaseDatasetTest):
+    @pytest.fixture(scope="class",
+                    params = [(load_tyr2ala, ('forward', 'backward'), (1, 1)),
+                              (load_idws, ('forward', ), (2,)),
+                              ])
+    def dataset(self, request):
+        return super(TestNAMD, self).dataset(request)


### PR DESCRIPTION
- modularized testing with a base class in `tests/__init__.py`
- simple tests for all NAMD datasets (#50 )
- simple tests for all GMX datasets (#51 )
- simple tests for all GOMC datasets (#52 )
- simple tests for _some_ AMBER datasets (#49 )
- configure coverage to not include tests
- simplified CI to reduce runtime for a worker from 2:30min to ~0:30min