### PR TITLE
increase coverage to 100% (test ALL AMBER files and all of __init__)

### DIFF
--- a/src/alchemtest/tests/test_amber.py
+++ b/src/alchemtest/tests/test_amber.py
@@ -1,6 +1,7 @@
 '''Tests for all the AMBER datasets'''
 import pytest
 
+from alchemtest import Bunch
 from alchemtest.amber import (load_bace_improper, load_bace_example,
                               load_simplesolvated, load_invalidfiles, )
 
@@ -17,22 +18,57 @@ class TestAMBER(BaseDatasetTest):
         return super(TestAMBER, self).dataset(request)
 
 
-# difficult -- has sub dicts under 'complex'/'solvated' -> 'decharge', 'recharge', 'vdw'
-# class TestBACEexample(BaseDatasetTest):
-#     @pytest.fixture(scope="class",
-#                     params = [(load_bace_example, ('complex',), (12,)),
-#                               ])
-#     def dataset(self, request):
-#         return super().dataset(request)
+# The BACE example dataset does not conform to the standard API because it
+# contains sub dicts under 'complex'/'solvated' -> 'decharge', 'recharge',
+# 'vdw' instead of lists of files. In order to use the same testing base class,
+# we create a fake data set for "complex" and "solvated" separatedly and pass
+# these accessor functions to the class.
+
+# fake access to conform to expected API
+def _load_bace_example_complex():
+    dset = load_bace_example()
+    return Bunch(data=dset.data['complex'],
+                 DESCR="BACE example: complex")
+
+def _load_bace_example_solvated():
+    dset = load_bace_example()
+    return Bunch(data=dset.data['solvated'],
+                 DESCR="BACE example: solvated")
+
+class TestBACEexample(BaseDatasetTest):
+    # use pytest.param to add the id for nicer pytest -v output
+    @pytest.fixture(scope="class",
+                    params = [
+                        pytest.param(
+                            (_load_bace_example_complex,
+                             ('decharge', 'recharge', 'vdw'),
+                             (5, 5, 12)),
+                            id="complex"),
+                        pytest.param(
+                            (_load_bace_example_solvated,
+                            ('decharge', 'recharge', 'vdw'),
+                            (5, 5, 12)),
+                            id="solvated"),
+                    ])
+    def dataset(self, request):
+        return super(TestBACEexample, self).dataset(request)
 
 
-# class TestInvalidFiles(BaseDatasetTest):
-#     # can't get the list of list in data
-#     @pytest.fixture(scope="class",
-#                     params = [(load_invalidfiles, (slice(None),), (6,)),
-#                               ])
-#     def dataset(self, request):
-#         return super().dataset(request)
+# The invalidfiles dataset does not conform to the API. load_invalidfiles()
+# returns a listv with just one element as data (and not a dict) so we create a
+# fake dataset:
+def _load_labelled_invalidfiles():
+    dset = load_invalidfiles()
+    return Bunch(data={'invalid_files': dset.data[0]},
+                 DESCR=dset.DESCR)
+
+class TestInvalidFiles(BaseDatasetTest):
+     @pytest.fixture(scope="class",
+                     params = [(_load_labelled_invalidfiles,
+                                ('invalid_files',), (6,)),
+                               ])
+     def dataset(self, request):
+         return super(TestInvalidFiles, self).dataset(request)
 
 
 

--- a/src/alchemtest/tests/test_utils.py
+++ b/src/alchemtest/tests/test_utils.py
@@ -1,0 +1,46 @@
+'''Tests for utility functions'''
+
+import pytest
+import pickle
+
+import alchemtest
+
+
+def test_version():
+    assert alchemtest.__version__
+
+
+@pytest.fixture
+def bunch():
+    return alchemtest.Bunch(data=[0, 1, 1, 2, 3, 5], DESCR="Fibonacci")
+
+class TestBunch:
+    def test_getattr_key(self, bunch):
+        assert bunch["DESCR"] == "Fibonacci"
+
+    def test_getattr_key(self, bunch):
+        assert bunch.DESCR == "Fibonacci"
+
+    def test_setattr_key(self, bunch):
+        bunch["foo"] = "bar"
+        assert bunch.foo == "bar"
+
+    def test_setattr_dot(self, bunch):
+        bunch.foo = "bar"
+        assert bunch.foo == "bar"
+
+    def test_missing_attr_AttributeError(self, bunch):
+        with pytest.raises(AttributeError):
+            bunch.unknown_attribute
+
+    def test_missing_key_KeyError(self, bunch):
+        with pytest.raises(KeyError):
+            bunch["unknown key"]
+
+    def test_dir(self, bunch):
+        bunch.a = "additional"
+        assert sorted(dir(bunch)) == ["DESCR", "a", "data"]
+
+    def test_serialize(self, bunch):
+        bunch_copy = pickle.loads(pickle.dumps(bunch))
+        assert bunch_copy == bunch


### PR DESCRIPTION
- fix #49
- test all untested AMBER data sets (custom tests (with hacked accessors) 
   for the AMBER BACE example and invalidfiles)
- test everything in `__init__.py` (`Bunch` and `__version__`)