### PR TITLE
renamed redundant test_getattr_key to test_getattr_dot in test_utils.py

### DIFF
--- a/src/alchemtest/tests/test_utils.py
+++ b/src/alchemtest/tests/test_utils.py
@@ -18,7 +18,7 @@ class TestBunch:
     def test_getattr_key(self, bunch):
         assert bunch["DESCR"] == "Fibonacci"
 
-    def test_getattr_key(self, bunch):
+    def test_getattr_dot(self, bunch):
         assert bunch.DESCR == "Fibonacci"
 
     def test_setattr_key(self, bunch):


### PR DESCRIPTION
I noticed that in `tests/test_utils.py::TestBunch` the method `test_getattr_key` is implemented twice, (the second one should be `test_getattr_dot` I think). Maybe it shouldn't be a problem, I am correct in my understanding that `pytest` will run everything starting with `test_`, regardless if it's re-implemented or not, but for sake of clarity, I renamed the method.