### PR TITLE
prepare for 1.0.0 release

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -17,6 +17,10 @@ concurrency:
   group: "${{ github.ref }}-${{ github.head_ref }}"
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash -l {0}
+
 jobs:
   test:
     name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}
@@ -48,15 +52,11 @@ jobs:
             python=${{ matrix.python-version }}
 
       - name: Install package
-        # conda setup requires this special shell
-        shell: bash -l {0}
         run: |
           python -m pip install . --no-deps
           micromamba list
 
       - name: Run tests
-        # conda setup requires this special shell
-        shell: bash -l {0}
         run: |
           pytest -v --cov=alchemtest --cov-report=xml --color=yes alchemtest/tests/
 

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -43,8 +43,7 @@ jobs:
             python-version: 3.13
     steps:
       - uses: actions/checkout@v5
-
-      - uses: uses: mamba-org/setup-micromamba@main
+      - uses: mamba-org/setup-micromamba@main
         with:
           environment-file: devtools/conda-envs/test_env.yaml
           environment-name: test

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -24,22 +24,14 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
         # Only test lowest and highest version on the expensive/slow
         # macOS and windows runners (UPDATE when supported versions change):
         exclude:
           - os: macOS-latest
-            python-version: 3.10
-          - os: macOS-latest
-            python-version: 3.11
-          - os: macOS-latest
             python-version: 3.12
           - os: macOS-latest
             python-version: 3.13
-          - os: windows-latest
-            python-version: 3.10
-          - os: windows-latest
-            python-version: 3.11
           - os: windows-latest
             python-version: 3.12
           - os: windows-latest

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -22,6 +22,7 @@ jobs:
     name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
         python-version: ["3.11", "3.12", "3.13", "3.14"]

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         # Only test lowest and highest version on the expensive/slow
         # macOS and windows runners (UPDATE when supported versions change):
         exclude:
@@ -32,13 +32,20 @@ jobs:
             python-version: 3.10
           - os: macOS-latest
             python-version: 3.11
+          - os: macOS-latest
+            python-version: 3.12
+          - os: macOS-latest
+            python-version: 3.13
           - os: windows-latest
             python-version: 3.10
           - os: windows-latest
             python-version: 3.11
-
+          - os: windows-latest
+            python-version: 3.12
+          - os: windows-latest
+            python-version: 3.13
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       # More info on options: https://github.com/marketplace/actions/provision-with-micromamba
       - uses: mamba-org/provision-with-micromamba@main
@@ -77,12 +84,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
 
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
-        python-version: 3.9
+        python-version: 3.12
 
     - name: Install tools
       run: |

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -40,13 +40,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      # More info on options: https://github.com/marketplace/actions/provision-with-micromamba
-      - uses: mamba-org/provision-with-micromamba@main
+      - uses: uses: mamba-org/setup-micromamba@main
         with:
           environment-file: devtools/conda-envs/test_env.yaml
           environment-name: test
-          channels: conda-forge,defaults
-          extra-specs: |
+          create-args: |
             python=${{ matrix.python-version }}
 
       - name: Install package

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,19 +29,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - name: setup_miniconda
-        uses: conda-incubator/setup-miniconda@v2
+      - name: Set up Python
+        uses: actions/setup-python@v6
         with:
-          python-version: 3.9
-          auto-update-conda: true
-          add-pip-as-python-dependency: true
-          architecture: x64
-
-      - name: install_deps
+          python-version: '3.12'
+      
+      - name: Install build dependencies
         run: |
           python -m pip install build
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: '3.11'
       
       - name: Install build dependencies
         run: |

--- a/alchemtest/amber/__init__.py
+++ b/alchemtest/amber/__init__.py
@@ -6,5 +6,4 @@ from .access import load_bace_improper
 from .access import load_bace_example
 from .access import load_tyk2_example
 from .access import load_simplesolvated
-from .access import load_invalidfiles
 from .access import load_testfiles

--- a/alchemtest/amber/access.py
+++ b/alchemtest/amber/access.py
@@ -104,43 +104,6 @@ def load_simplesolvated():
                  DESCR=fdescr)
 
 
-def load_invalidfiles():
-    """Load the invalid files.
-
-    Returns
-    -------
-    data : Bunch
-        Dictionary-like object, the interesting attributes are:
-
-        - 'data' : the example of invalid data files
-        - 'DESCR': the full description of the dataset
-
-
-    .. deprecated:: 0.7
-       use :func:`load_testfiles` instead
-
-    """
-
-    warnings.warn(
-        "load_invalidfiles() was deprecated in 0.7.0 and will be removed in the following release."
-        " Use load_testfiles() instead",
-        DeprecationWarning)
-    module_path = Path(__file__).parent
-    data = [[
-        module_path / 'testfiles' / 'no_useful_data.out.bz2',
-        module_path / 'testfiles' / 'no_control_data.out.bz2',
-        module_path / 'testfiles' / 'no_temp0_set.out.bz2',
-        module_path / 'testfiles' / 'no_free_energy_info.out.bz2',
-        module_path / 'testfiles' / 'no_atomic_section.out.bz2',
-        module_path / 'testfiles' / 'no_results_section.out.bz2']]
-
-    with open(module_path / 'testfiles' / 'descr_invalid.rst') as rst_file:
-        fdescr = rst_file.read()
-
-    return Bunch(data=data,
-                 DESCR=fdescr)
-
-
 def load_testfiles():
     """Load incomplete or wrongly formatted files to be used to test the AMBER parsers.
 

--- a/alchemtest/tests/test_amber.py
+++ b/alchemtest/tests/test_amber.py
@@ -3,7 +3,7 @@ import pytest
 
 from alchemtest import Bunch
 from alchemtest.amber import (load_bace_improper, load_bace_example,
-                              load_simplesolvated, load_invalidfiles, 
+                              load_simplesolvated, 
                               load_testfiles, load_tyk2_example)
 
 
@@ -86,22 +86,6 @@ class TestTYK2example(BaseDatasetTest):
     def dataset(self, request):
         return super(TestTYK2example, self).dataset(request)
 
-
-# The invalidfiles dataset does not conform to the API. load_invalidfiles()
-# returns a listv with just one element as data (and not a dict) so we create a
-# fake dataset:
-def _load_labelled_invalidfiles():
-    dset = load_invalidfiles()
-    return Bunch(data={'invalid_files': dset.data[0]},
-                 DESCR=dset.DESCR)
-
-class TestInvalidFiles(BaseDatasetTest):
-     @pytest.fixture(scope="class",
-                     params = [(_load_labelled_invalidfiles,
-                                ('invalid_files',), (6,)),
-                               ])
-     def dataset(self, request):
-         return super(TestInvalidFiles, self).dataset(request)
 
 
 

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -1,9 +1,6 @@
 name: test
 channels:
-
   - conda-forge
-
-  - defaults
 dependencies:
     # Base depends
   - python

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -13,6 +13,6 @@ dependencies:
 
   - wheel
   - pytest-pep8
-  - build
+  - python-build
 
 

--- a/docs/amber.rst
+++ b/docs/amber.rst
@@ -18,7 +18,6 @@ They can be accessed using the following accessor functions:
    load_bace_improper
    load_bace_example
    load_simplesolvated
-   load_invalidfiles
    load_testfiles
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ authors = [
 license = { text = "BSD-3-Clause" }
 # See https://pypi.org/classifiers/
 classifiers = [
-    'Development Status :: 4 - Beta',
+    'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Science/Research',
     'License :: OSI Approved :: BSD License',
     'Operating System :: POSIX',
@@ -28,6 +28,8 @@ classifiers = [
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.14',
     'Topic :: Scientific/Engineering',
     'Topic :: Scientific/Engineering :: Bio-Informatics',
     'Topic :: Scientific/Engineering :: Chemistry',
@@ -38,7 +40,6 @@ requires-python = ">=3.9"
 #    "importlib-resources;python_version<'3.10'",
 #]
 
-# Update the urls once the hosting is set up.
 [project.urls]
 "Source" = "https://github.com/alchemistry/alchemtest/"
 "Documentation" = "https://alchemtest.readthedocs.io/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     'Topic :: Scientific/Engineering :: Bio-Informatics',
     'Topic :: Scientific/Engineering :: Chemistry',
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 # Declare any run-time dependencies that should be installed with the package.
 #dependencies = [
 #    "importlib-resources;python_version<'3.10'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,6 @@ classifiers = [
     'Operating System :: MacOS :: MacOS X',
     'Operating System :: Microsoft :: Windows ',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 3.9',
-    'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',


### PR DESCRIPTION
## Description
Let's put alchemtest into stable and release 1.0.0

## Changes
* support Python 3.14 and 3.13
* removed support for 3.9 and 3.10: officially supporting Python 3.11 - 3.14 (same as alchemlyb)
* update CI to test 3.9 - 3.14
* updated workflows
* removed deprecated AMBER load_invalidfiles() function