### PR TITLE
Update link to NIST data

### DIFF
--- a/alchemtest/lammps/benzene/descr.rst
+++ b/alchemtest/lammps/benzene/descr.rst
@@ -26,8 +26,8 @@ Data Set Characteristics:
     :License: `NIST <https://www.nist.gov/disclaimer>`_    
     :DOI: 10.18434/mds2-3637
 
-This dataset was provided by @jaclark5 in
-`NIST Data Discovery <https://data.nist.gov/>`_
+This dataset was provided by @jaclark5 in the
+`NIST Data Repository <https://data.nist.gov/>`_
 
 Experimental value sourced from [Mobley2013]_.
 

--- a/alchemtest/lammps/lj_dimer/descr.rst
+++ b/alchemtest/lammps/lj_dimer/descr.rst
@@ -25,5 +25,5 @@ Data Set Characteristics:
     :License: `NIST <https://www.nist.gov/disclaimer>`_    
     :DOI: 10.18434/mds2-3637
 
-This dataset was provided by @jaclark5 in
-`NIST Data Discovery <https://data.nist.gov/>`_
+This dataset was provided by @jaclark5 in the
+`NIST Data Repository <https://data.nist.gov/>`_


### PR DESCRIPTION
## Description
NIST changed the link to their data repository from MIDAS to the NIST Data Repository

## Todos
  - [X] Update link